### PR TITLE
ng-springweb-2019062001 to v0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: v0.0.2
 - name: ng-springweb-2019062001
   repository: http://jenkins-x-chartmuseum:8080
-  version: v0.0.2
+  version: v0.0.3


### PR DESCRIPTION
Promote ng-springweb-2019062001 to version v0.0.3